### PR TITLE
Use an earlier hook in the constructor

### DIFF
--- a/WP_Logging.php
+++ b/WP_Logging.php
@@ -22,10 +22,10 @@ class WP_Logging {
 	function __construct() {
 
 		// create the log post type
-		add_action( 'init', array( $this, 'register_post_type' ), -1 );
+		add_action( 'plugins_loaded', array( $this, 'register_post_type' ) );
 		
 		// create types taxonomy and default types
-		add_action( 'init', array( $this, 'register_taxonomy' ), -1 );
+		add_action( 'plugins_loaded', array( $this, 'register_taxonomy' ) );
 
 	}
 


### PR DESCRIPTION
The idea behind a low (negative) priority is to make sure you get in befor any other code tries to use this functionality.  That seems like a good use for a hook earlier than init to me.

'plugins_loaded' is a good place to count on this code being loaded before others try to use it.
