### PR TITLE
add_rewrite_tag error on register_taxonomy

### DIFF
--- a/WP_Logging.php
+++ b/WP_Logging.php
@@ -22,10 +22,10 @@ class WP_Logging {
 	function __construct() {
 
 		// create the log post type
-		add_action( 'plugins_loaded', array( $this, 'register_post_type' ) );
+		add_action( 'init', array( $this, 'register_post_type' ) );
 
 		// create types taxonomy and default types
-		add_action( 'plugins_loaded', array( $this, 'register_taxonomy' ) );
+		add_action( 'init', array( $this, 'register_taxonomy' ) );
 
 	}
 


### PR DESCRIPTION
On my local install I'm getting an issue:

`Fatal error: Call to a member function add_rewrite_tag() on a non-object in /Sites/wptt-development/wp-includes/rewrite.php on line 51`

Looking through other docs on registering taxonomies it seems that it should be registered on the 'init' hook. WP_Logging is loading on 'plugins_loaded' which looks like is set before our taxonomy objects are set (hence the error).

Changing to 'init' fixes the error.

Changing register_post_type to init brings it in to line with register_taxonomy
