### PR TITLE
updated pruning get_posts args and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You could also register additional log types using a filter:
 
 ```php
 function pw_add_log_types( $types ) {
-	
+
 	$types[] = 'registration';
 	return $types;
 
@@ -179,7 +179,7 @@ $count = WP_Logging::get_log_count( 57, 'error', $meta_query );
 Pruning Logs
 ======================
 
-To prune older logs you need to first set the pruning conditional to true then set up a cron job to perform the pruning.
+To prune older logs you need to first set the pruning conditional to true then set up a cron job to perform the pruning. It's recommended you set the cron job to hourly so that you can stay on top of pruning your logs. Running daily and deleting 100 logs (the default number) means that many sites would never actually stay caught up with log prunning.
 
 ```php
 function activate_pruning( $should_we_prune ){
@@ -190,7 +190,7 @@ add_filter( 'wp_logging_should_we_prune', 'activate_pruning', 10 );
 
 $scheduled = wp_next_scheduled( 'wp_logging_prune_routine' );
 if ( $scheduled == false ){
-	wp_schedule_event( time(), 'daily', 'wp_logging_prune_routine' );
+	wp_schedule_event( time(), 'hourly', 'wp_logging_prune_routine' );
 }
 ```
 
@@ -203,7 +203,7 @@ function change_prune_time( $time ){
 add_filter( 'wp_logging_prune_when', 'change_prune_time' );
 ```
 
-The pruning query is run via `get_posts` and you can filter any arguement in the array with the `wp_logging_prune_query_args` filter.
+The pruning query is run via `get_posts` and you can filter any arguement in the array with the `wp_logging_prune_query_args` filter. By default we prune 100 logs each time the pruning routine is run. You could certainly up this number if your server will handle the load.
 
 Logs are set to bypass the WordPress trash system. If you want to have logs hit the WordPress trash system then you'd need to filter `wp_logging_force_delete_log` and return false.
 

--- a/WP_Logging.php
+++ b/WP_Logging.php
@@ -98,8 +98,9 @@ class WP_Logging {
 		$how_old = apply_filters( 'wp_logging_prune_when', '2 weeks ago' );
 
 		$args = array(
-			'post_type'    => 'wp_log',
-			'date_query'   => array(
+			'post_type'      => 'wp_log',
+			'posts_per_page' => '100',
+			'date_query'     => array(
 				array(
 					'column' => 'post_date_gmt',
 					'before' => (string) $how_old,


### PR DESCRIPTION
This updates the get_posts args to 100 posts. It would have just grabbed
the default for the site which is 10 posts. Few sites that would take
the time to log would ever catch up to generated logs if they only
pruned 10 logs.

Now we prune 100 logs every time the routines are run.

Docs are update to recommend hourly pruning and add details of the
get_posts args changes.
