### PR TITLE
Turning WP-Logging to a Composer package

### DIFF
--- a/WP_Logging.php
+++ b/WP_Logging.php
@@ -1,4 +1,5 @@
 <?php
+namespace pippinsplugins;
 
 /**
  * Class for logging events and errors
@@ -441,4 +442,3 @@ class WP_Logging {
 	}
 
 }
-$GLOBALS['wp_logs'] = new WP_Logging();

--- a/composer.json
+++ b/composer.json
@@ -10,5 +10,10 @@
  	"keywords": ["wordpress", "logging", "logger", "log"],
  	"require" : {
     		"php" : ">=5.2.0"
-	}
+	},
+	"autoload": {
+        "psr-4": {
+            "pippinsplugins\\": ""
+        }
+    }
 }


### PR DESCRIPTION
I'm using this for my WP Boilerplate ( https://github.com/omarabid/WordPress-Plugin-Boilerplate )

I added a namespace, removed the initialization of the class and added autoloading params for composer. It'll enable, who wishes to use composer, to automatically download and autoload it.

It'll be used this way: https://github.com/omarabid/WordPress-Plugin-Boilerplate/blob/master/plugin.php#L87

If you are okay for this change, then you might want to consider submitting it as a Composer package too.